### PR TITLE
Trouble getting this to work with Fedora 34

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This extension is a fork of [schuhumi/gnome-shell-extension-improve-osk](https:/
 Clone the git repo
 
 ```console
-git clone https://github.com/SebastianLuebke/improved-osk-gnome-ext.git ~/.local/share/gnome-shell/extensions/improvedosk@luebke.io
+git clone https://github.com/nick-shmyrev/improved-osk-gnome-ext.git ~/.local/share/gnome-shell/extensions/improvedosk@luebke.io
 ```
 
 reload gnome by pressing alt + F2 and enter r


### PR DESCRIPTION
Sorry, but I found no other way to give feedback. Do you know a way to fix this?
```
Error: No property margin on GtkGrid

Stack trace:
  _init/Gtk.Widget.prototype._init@resource:///org/gnome/gjs/modules/core/overrides/Gtk.js:45:40
  buildPrefsWidget@/home/surface/.local/share/gnome-shell/extensions/improvedosk@luebke.io/prefs.js:25:21
  _init@resource:///org/gnome/Shell/Extensions/js/extensionsService.js:209:40
  OpenExtensionPrefsAsync/<@resource:///org/gnome/Shell/Extensions/js/extensionsService.js:122:28
  asyncCallback@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:115:22
  run@resource:///org/gnome/Shell/Extensions/js/dbusService.js:177:20
  main@resource:///org/gnome/Shell/Extensions/js/main.js:19:13
  run@resource:///org/gnome/gjs/modules/script/package.js:206:19
  start@resource:///org/gnome/gjs/modules/script/package.js:190:8
  @/usr/share/gnome-shell/org.gnome.Shell.Extensions:1:17
```

I get that when I try to active the plugin on Fedora 34 Workstation (Gnome 40).