### PR TITLE
Update README and metadata so it doesn't get autoupdated by the old upstream project

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This extension is a fork of [schuhumi/gnome-shell-extension-improve-osk](https:/
 Clone the git repo
 
 ```console
-git clone https://github.com/SebastianLuebke/improved-osk-gnome-ext.git ~/.local/share/gnome-shell/extensions/improvedosk@luebke.io
+git clone https://github.com/nick-shmyrev/improved-osk-gnome-ext.git ~/.local/share/gnome-shell/extensions/improvedosk@luebke.io
 ```
 
 reload gnome by pressing alt + F2 and enter r

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This extension is a fork of [schuhumi/gnome-shell-extension-improve-osk](https:/
 Clone the git repo
 
 ```console
-git clone https://github.com/nick-shmyrev/improved-osk-gnome-ext.git ~/.local/share/gnome-shell/extensions/improvedosk@luebke.io
+git clone https://github.com/nick-shmyrev/improved-osk-gnome-ext.git ~/.local/share/gnome-shell/extensions/improvedosk@nick-shmyrev
 ```
 
 reload gnome by pressing alt + F2 and enter r

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
     "3.38",
     "40"
   ],
-  "url": "https://github.com/SebastianLuebke/improved-osk-gnome-ext",
-  "uuid": "improvedosk@luebke.io",
+  "url": "https://github.com/nick-shmyrev/improved-osk-gnome-ext",
+  "uuid": "improvedosk@nick-shmyrev",
   "version": 5
 }


### PR DESCRIPTION
With these changes you don't get the plugin overwritten by upstream in Gnome Extensions. See https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/2514