### PR TITLE
Add dbus binding for toggling osk

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -58,6 +58,11 @@ let OSKIndicator = GObject.registerClass(
       this.connect("touch-event", function () {
         toggleOSK();
       });
+      
+      settings.connect("changed::toggle", function () {
+        toggleOSK();
+        settings.set_boolean('toggle', false);
+      });
     }
   }
 );

--- a/src/extension.js
+++ b/src/extension.js
@@ -61,7 +61,6 @@ let OSKIndicator = GObject.registerClass(
       
       settings.connect("changed::toggle", function () {
         toggleOSK();
-        settings.set_boolean('toggle', false);
       });
     }
   }

--- a/src/extension.js
+++ b/src/extension.js
@@ -58,10 +58,6 @@ let OSKIndicator = GObject.registerClass(
       this.connect("touch-event", function () {
         toggleOSK();
       });
-      
-      settings.connect("changed::toggle", function () {
-        toggleOSK();
-      });
     }
   }
 );
@@ -393,6 +389,10 @@ function enable() {
   Main.layoutManager.addTopChrome(Main.layoutManager.keyboardBox, {
     affectsStruts: settings.get_boolean("resize-desktop"),
     trackFullscreen: false,
+  });
+  
+  settings.connect("changed::toggle", function () {
+    toggleOSK();
   });
 }
 

--- a/src/schemas/org.gnome.shell.extensions.improvedosk.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.improvedosk.gschema.xml
@@ -21,5 +21,8 @@
     <key name="portrait-height" type="i">
       <default>16</default>
     </key>
+    <key name="toggle" type="b">
+      <default>false</default>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Following up the issue #32 I created, this PR implements that feature.